### PR TITLE
XMMatrixPerspectiveOffCenterLH : Fix math error in SSE path

### DIFF
--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -3258,9 +3258,6 @@ pub fn XMMatrixPerspectiveFovRH(
     }
 }
 
-// TODO: XMMatrixPerspectiveOffCenterLH
-// TODO: XMMatrixPerspectiveOffCenterRH
-
 /// Builds an orthogonal projection matrix for a left-handed coordinate system.
 ///
 /// ## Parameters

--- a/src/matrix.rs
+++ b/src/matrix.rs
@@ -3553,7 +3553,7 @@ pub fn XMMatrixPerspectiveOffCenterLH(
         let rMem: XMVECTORF32 = XMVECTORF32 { f: [
             TwoNearZ * ReciprocalWidth,
             TwoNearZ * ReciprocalHeight,
-            -fRange,
+            -fRange * NearZ,
             0.0,
         ]};
         // Copy from memory to SSE register


### PR DESCRIPTION
Hello!

It seems an error has slipped in the implementation of `XMMatrixPerspectiveOffCenterLH()`'s SSE path: The 3rd float in the stack allocated m128 vector should be multiplied by the near clip distance.

For cross reference, here's the original C++ implementation: https://github.com/microsoft/DirectXMath/blob/main/Inc/DirectXMathMatrix.inl#L2710